### PR TITLE
Make harvesterVersion have explicit major/minor fields (BL-7498)

### DIFF
--- a/cloud/main.js
+++ b/cloud/main.js
@@ -611,7 +611,8 @@ Parse.Cloud.define("setupTables", function(request, response) {
                 // Fields required by Harvester
                 {name: "harvestState", type:"String"},
                 {name: "harvesterId", type:"String"},
-                {name: "harvesterVersion", type:"String"},
+                {name: "harvesterMajorVersion", type:"String"},
+                {name: "harvesterMinorVersion", type:"String"},
                 {name: "harvestStartedAt", type:"Date"},
                 {name: "harvestLog", type:"Array"},
                 // End fields required by Harvester


### PR DESCRIPTION
This will make it easier for the Harvester to write more sophisticated queries against Parse to determine which books to process.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloom-parse-server/31)
<!-- Reviewable:end -->
